### PR TITLE
Remove deprecated RS_AUDIO option

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,6 @@ services:
           - RS_LOGLEVEL=4
           - RS_TIMEZONE=Europe/Berlin
           - RS_SNAPSHOT_INTERVAL=1m
-          - RS_AUDIO=auto
         deploy:
           replicas: 1
           restart_policy:


### PR DESCRIPTION
As [from the documentation](https://datarhei.github.io/restreamer/docs/references-environment-vars.html#rs_audio):

> As of Restreamer version 0.4.0, this environment variable is deprecated and doesn’t have any effect.