### PR TITLE
Frontend port fixes, added https-portal and stunnel for docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,24 +1,57 @@
-version: '3'
+version: "3"
 services:
-    restreamer:
-        image: datarhei/restreamer
-        ports:
-            - "8080:8080"
-        networks:
-            - frontend
-        volumes:
-            - "~/db:/restreamer/db"
-        environment:
-          - RS_USERNAME=admin
-          - RS_PASSWORD=datarhei
-          - RS_LOGLEVEL=4
-          - RS_TIMEZONE=Europe/Berlin
-          - RS_SNAPSHOT_INTERVAL=1m
-        deploy:
-          replicas: 1
-          restart_policy:
-            condition: any
-            delay: 5s
-            window: 10s
+  restreamer:
+    image: datarhei/restreamer
+    container_name: restreamer
+    ports:
+      - 1935:1935
+      - 8080:8080
+    networks:
+      - frontend
+    volumes:
+      - "~/db:/restreamer/db"
+    environment:
+      - RS_USERNAME=admin
+      - RS_PASSWORD=datarhei
+      - RS_LOGLEVEL=4
+      - RS_TIMEZONE=Europe/Berlin
+      - RS_SNAPSHOT_INTERVAL=1m
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: any
+        delay: 5s
+        window: 10s
+
+  fblive:
+    image: dweomer/stunnel
+    container_name: fblive
+    expose:
+      - 1935
+    networks:
+      - frontend
+    restart: always
+    environment:
+      - STUNNEL_SERVICE=fb-live
+      - STUNNEL_CLIENT=yes
+      - STUNNEL_ACCEPT=1935
+      - STUNNEL_CONNECT=live-api-s.facebook.com:443
+      - STUNNEL_VERIFY_CHAIN=NO
+
+  https-portal:
+    image: steveltn/https-portal:1
+    container_name: https-portal
+    ports:
+      - 80:80
+      - 443:443
+    restart: always
+    networks:
+      - frontend
+    environment:
+      DOMAINS: localhost -> http://restreamer:8080
+      STAGE: local
+      # DOMAINS: yourdomain.com -> http://restreamer:8080
+      # STAGE: production
+
 networks:
   frontend:

--- a/src/webserver/public/index.dev.html
+++ b/src/webserver/public/index.dev.html
@@ -94,8 +94,8 @@
                         <span class="glyphicon glyphicon-question-sign icon16" aria-hidden="true"></span>
                     </a>
                 </h4>
-                <pre>&lt;iframe src="http://{{publicIp}}:{{windowLocationPort}}{{windowLocationPath}}player.html" name="restreamer-player" width="800" height="450" scrolling="no" frameborder="0" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen="true"&gt;&lt;/iframe&gt;</pre>
-                <pre>&lt;img src="http://{{publicIp}}:{{windowLocationPort}}{{windowLocationPath}}images/live.jpg" width="800" height="450"&gt;</pre>
+                <pre>&lt;iframe src="{{windowProtocol}}//{{publicIp}}{{windowLocationPort}}{{windowLocationPath}}player.html" name="restreamer-player" width="800" height="450" scrolling="no" frameborder="0" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen="true"&gt;&lt;/iframe&gt;</pre>
+                <pre>&lt;img src="{{windowProtocol}}//{{publicIp}}{{windowLocationPort}}{{windowLocationPath}}images/live.jpg" width="800" height="450"&gt;</pre>
                 <p>{{'player_modal_help_content' | translate}}
                     <a href="{{config.urls.portForwardingHelp}}" target="_blank" class="underline">
                         <span class="glyphicon glyphicon-question-sign icon14" aria-hidden="true"></span>

--- a/src/webserver/public/index.prod.html
+++ b/src/webserver/public/index.prod.html
@@ -64,8 +64,8 @@
                         <span class="glyphicon glyphicon-question-sign icon16" aria-hidden="true"></span>
                     </a>
                 </h4>
-                <pre>&lt;iframe src="http://{{publicIp}}:{{windowLocationPort}}{{windowLocationPath}}player.html" name="restreamer-player" width="800" height="450" scrolling="no" frameborder="0" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen="true"&gt;&lt;/iframe&gt;</pre>
-                <pre>&lt;img src="http://{{publicIp}}:{{windowLocationPort}}{{windowLocationPath}}images/live.jpg" width="800" height="450"&gt;</pre>
+                <pre>&lt;iframe src="{{windowProtocol}}//{{publicIp}}{{windowLocationPort}}{{windowLocationPath}}player.html" name="restreamer-player" width="800" height="450" scrolling="no" frameborder="0" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen="true"&gt;&lt;/iframe&gt;</pre>
+                <pre>&lt;img src="{{windowProtocol}}//{{publicIp}}{{windowLocationPort}}{{windowLocationPath}}images/live.jpg" width="800" height="450"&gt;</pre>
                 <p>{{'player_modal_help_content' | translate}}
                     <a href="{{config.urls.portForwardingHelp}}" target="_blank" class="underline">
                         <span class="glyphicon glyphicon-question-sign icon14" aria-hidden="true"></span>

--- a/src/webserver/public/scripts/Main/MainController.js
+++ b/src/webserver/public/scripts/Main/MainController.js
@@ -133,10 +133,11 @@ window.angular.module('Main').controller('mainController',
             addresses: {
                 optionalOutputAddress: '',
                 srcAddress: ''
-            }
+            },
         };
 
-        $rootScope.windowLocationPort = window.location.port;
+        $rootScope.windowProtocol = window.location.protocol;
+        $rootScope.windowLocationPort = window.location.port ? `:${window.location.port}` : '';
         $rootScope.windowLocationPath = window.location.pathname;
 
         $scope.optionalOutput = '';


### PR DESCRIPTION
### Description
I've fixed some weird issues appearing in the web interface if you decide to use https and just stick to the normal ports. Before if there was no special port specified, the embed urls would be printed with a colon without a port number behind it. Also if you had enabled https on the server, the embed url would still be in http.

### Addition
As I was looking into optimizing the configuration for docker and pushing video to fb (using https) I've adjusted the docker combination and added the `https-portal` and `stunnel` containers.

#### https-portal
This portal enables you to automatically get a SSL certificate from lets-encrypt which automatically gets renewed for the provided (sub)domain name. This makes it a lot easier to provide https to the webinterface instead of having to provide the fullchain.pem file yourself. The portal wil also automatically redirect http traffic to the https and proxy it to the restreamer container.

By default _https-portal_ will create a self-signed certificate for localhost. Chrome / Most browsers don't like this, so to fix this, make sure your provided (sub)domain is pointing to the public IP address of this server. Then comment out these lines:
```
# DOMAINS: localhost -> http://restreamer:8080
# STAGE: local
```
And uncomment these lines:
```
DOMAINS: yourdomain.com -> http://restreamer:8080
STAGE: production
```
Where yourdomain.com is your provided (sub)domain. The whole process should take only a couple of minutes and the certbot will make sure the certificate gets renewed automatically.

#### stunnel
This enables you to encrypt your RTMP traffic using TLS, and allows you to publish your stream to Facebook using their provided streamkey (later referred to as FB_STREAMKEY). To achieve this follow the following steps:
1) Obtain a persistent streamKey in your Facebook Profile/Page live stream section.
2) Publish the RTMP stream to your restreamer instance, using the provided key in the RS_TOKEN.
For example if you're token is set to __e292ufeje90fiTOKEN__, this would mean you would set OBS (or whatever software you're using) to a Custom RTMP server using `rtmp://{public-ip}/live/external.stream?token=e292ufeje90fiTOKEN`
3) In your restreamer instance, start restreaming the stream using the similar url, but use the local (127.0.0.1) ip addres, e.g. `rtmp://127.0.0.1/live/external.stream?token=e292ufeje90fiTOKEN`
4) When the video is up and running, enable the optional output stream, and use the following url:
rtmp://127.0.0.1/rtmp/{FB_STREAMKEY}

Note: If you've activated a domain name using https-portal you can also use this instead of the public IP address.