### PR TITLE
Documentation typo fixes and add docker compose example

### DIFF
--- a/docs/references-config.md
+++ b/docs/references-config.md
@@ -150,7 +150,7 @@ More about the [environment variables](references-environment-vars.html).
 }
 ```
 
-Preset for FFmpeg. The selected presets depend on the incoming stream and the environmet variable for the audio setting. By default, it is assumed, that
+Preset for FFmpeg. The selected presets depend on the incoming stream and the environment variable for the audio setting. By default, it is assumed, that
 the stream has no audio (`native_h264_no_audio`). If there is an audio track, `native_h264_native_audio` will be selected. In case the audio track
 is encoded with AAC, then the preset `native_h264_native_aac` gets selected (to fix possible errors in the audio stream). If the audio stream is
 not supported by the FLV container, it will be transcoded to AAC with the preset `native_h264_transcode_aac`. 
@@ -171,7 +171,7 @@ The selection of the incoming video stream preset can be influenced by the `RS_A
 }
 ```
 
-The running FFmpeg process is monitord. If the process stops, it will be automatically restarted after `restart_wait` milliseconds. If the process
+The running FFmpeg process is monitored. If the process stops, it will be automatically restarted after `restart_wait` milliseconds. If the process
 is stale, i.e. no incoming data is processed, FFmpeg will be automatically restart after `stale_wait` milliseconds.
 
 ## NGINX

--- a/docs/references-environment-vars.md
+++ b/docs/references-environment-vars.md
@@ -45,6 +45,31 @@ docker run ...
 **Kitematic example:**
 ![Kitematic Environment Variables](../img/references-environment-variables.png)
 
+**Docker Compose example:**
+
+Change environment variables on your `docker-compose.yml` file
+```sh
+version: "3"
+services:
+  restreamer:
+    image: datarhei/restreamer
+    ...
+    environment:
+      - RS_LOGLEVEL=4
+      - RS_SNAPSHOT_INTERVAL=10000
+    ...
+  ...
+...
+```
+From your `docker-compose.yml` directory, execute
+```sh
+docker-compose up
+```
+or
+```sh
+docker-compose -f /path/to/docker-compose.yml up
+```
+
 
 ## RS_USERNAME
 

--- a/docs/references-environment-vars.md
+++ b/docs/references-environment-vars.md
@@ -113,7 +113,7 @@ Whether to enable [HTTPS support](guides-https.html).
 
 ## RS_LOGLEVEL
 
-Restreamer writes some information to the console (stdout). With this environment variable you can crontrol how "chatty" Restreamer is.
+Restreamer writes some information to the console (stdout). With this environment variable you can control how "chatty" Restreamer is.
 The different logging levels are
 
 | Value | Level   | Description |


### PR DESCRIPTION
Hi, some changes in this PR are :
- fixed typos in 'references-environment-vars' and 'references-config'
- added using docker-compose for 'environment variables'. trying to maintain consistency with examples on 'https'

**checklist** 
- [v] build with jekyll and reviewed.

**preview** 
![image](https://user-images.githubusercontent.com/46004242/89941602-714dce00-dc45-11ea-9548-2f43be625946.png)

please let me know what you think.