### PR TITLE
🐛 Fix dual-stack binding for rtmp server

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -9,7 +9,7 @@ events {
 
 rtmp {
     server {
-        listen 1935;
+        listen [::]:1935 ipv6only=off;
         chunk_size 4000;
 
         application live {

--- a/conf/nginx_ssl.conf
+++ b/conf/nginx_ssl.conf
@@ -9,7 +9,7 @@ events {
 
 rtmp {
     server {
-        listen 1935;
+        listen [::]:1935 ipv6only=off;
         chunk_size 4000;
 
         application live {


### PR DESCRIPTION
- Workaround for a bug of the rtmp module where separate bindings of IPv4 and IPv6 socket cause error.